### PR TITLE
Option to catch install promise error

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -39,7 +39,12 @@ export default {
         window.google.accounts.id.initialize(idConfiguration);
         options.prompt && window.google.accounts.id.prompt();
       }
-    });
-    app.component("GoogleLogin", GoogleLogin);
+    }).catch((e) => {
+		if(!options.error)
+			throw e;
+
+		options.error(e);
+	});
+	app.component("GoogleLogin", GoogleLogin);
   },
 };


### PR DESCRIPTION
Install promise did not have catch. InstallOptions has an error property that can be used to pass a function to handle the exception. Added catch to allow for this.